### PR TITLE
shadow _ENV instead of setting it to nil

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,8 +96,8 @@ test:
 	cd $(SRC) && prove --exec=$(LUA) ../test/*.t
 
 luacheck:
-	luacheck --std=max --codes src --ignore 212 --ignore 213 --ignore 311/j
-	luacheck --std=max --codes src5.3 --ignore 212 --ignore 213 --ignore 311/j
+	luacheck --std=max --codes src --ignore 211/_ENV 212 213 311/j
+	luacheck --std=max --codes src5.3 --ignore 211/_ENV 212 213 311/j
 	luacheck --std=max --config .test.luacheckrc test/*.t
 
 coverage:

--- a/src/MessagePack.lua
+++ b/src/MessagePack.lua
@@ -40,7 +40,7 @@ local function hexadump (s)
 end
 --]]
 
-_ENV = nil
+local _ENV = nil
 local m = {}
 
 --[[ debug only

--- a/src5.3/MessagePack.lua
+++ b/src5.3/MessagePack.lua
@@ -23,7 +23,7 @@ local function hexadump (s)
 end
 --]]
 
-_ENV = nil
+local _ENV = nil
 local m = {}
 
 --[[ debug only


### PR DESCRIPTION
This should not change anything in normal usage, but it makes the module usable with tools like soar (which packs several Lua modules into one file) and it keeps tools which check for global use happy (see [this issue](https://github.com/harningt/luajson/issues/25) on luajson).