### PR TITLE
avoid an error when calling ipairs() on packers

### DIFF
--- a/src/MessagePack.lua
+++ b/src/MessagePack.lua
@@ -60,7 +60,10 @@ local function checktype (caller, narg, arg, tname)
 end
 
 local packers = setmetatable({}, {
-    __index = function (t, k) error("pack '" .. k .. "' is unimplemented") end
+    __index = function (t, k)
+        -- return nil for k == 1 to avoid breaking ipairs()
+        if k ~= 1 then error("pack '" .. k .. "' is unimplemented") end
+    end
 })
 m.packers = packers
 

--- a/src5.3/MessagePack.lua
+++ b/src5.3/MessagePack.lua
@@ -43,7 +43,10 @@ local function checktype (caller, narg, arg, tname)
 end
 
 local packers = setmetatable({}, {
-    __index = function (t, k) error("pack '" .. k .. "' is unimplemented") end
+    __index = function (t, k)
+        -- return nil for k == 1 to avoid breaking ipairs()
+        if k ~= 1 then error("pack '" .. k .. "' is unimplemented") end
+    end
 })
 m.packers = packers
 

--- a/test/02-except.t
+++ b/test/02-except.t
@@ -2,7 +2,7 @@
 
 require 'Test.More'
 
-plan(23)
+plan(24)
 
 local mp = require 'MessagePack'
 
@@ -114,6 +114,10 @@ error_like( function ()
 
 lives_ok( function ()
                 mp.packers['fixext4']({}, 1, '1234')
-            end,
-            "fixext4" )
+          end,
+          "fixext4" )
 
+lives_ok( function ()
+                for _ in ipairs(mp.packers) do end
+           end,
+           "cannot iterate packers" )


### PR DESCRIPTION
I sent a message regarding this issue to the Lua mailing list and Hisham suggested this fix.

The original use case was I did this:

    local mp = require "MessagePack"
    local pretty = require "pl.pretty"
    pretty.dump(mp)

and it broke because calling `ipairs()` on the packers table raised an error.